### PR TITLE
Support for comments in config and UTF-8 fix

### DIFF
--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -259,8 +259,14 @@ TEXT="${TEXT//$"\n"/${LINE_BREAK}}"
 TEXT=$(trim "$TEXT")
 
 # if title defined, add it with line break
-[ "${TITLE}" != "" ] && [ "${MODE}" = "html" ] && TEXT="<b>${TITLE}</b>${LINE_BREAK}${LINE_BREAK}${TEXT}"
-[ "${TITLE}" != "" ] && [ "${MODE}" = "markdown" ] && TEXT="*${TITLE}*${LINE_BREAK}${LINE_BREAK}${TEXT}"
+if [ "${TITLE}" != "" ]; then
+  # convert \n to LF and trim
+  TITLE="${TITLE//$"\n"/${LINE_BREAK}}"
+  TITLE=$(trim "$TITLE")
+
+  [ "${MODE}" = "html" ] && TEXT="<b>${TITLE}</b>${LINE_BREAK}${LINE_BREAK}${TEXT}"
+  [ "${MODE}" = "markdown" ] && TEXT="*${TITLE}*${LINE_BREAK}${LINE_BREAK}${TEXT}"
+fi
 
 # if icon defined, include ahead of notification
 [ "${ICON}" != "" ] && TEXT="${ICON} ${TEXT}"

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -25,14 +25,18 @@
 # ---------------------------------------------------
 
 # initialise variables
-API_KEY=""
-USER_ID=""
+export API_KEY=""
+export USER_ID=""
 SOCKS_PROXY=""
-DEBUG=""
-DEBUG_KEY=""
-TEXT=""
-ICON=""
-TYPE="text"
+export RC=1
+export DEBUG="false"
+DEBUG_KEY="false"
+VERBOSE="false"
+export TEXT=""
+export FILE=""
+export ICON=""
+export TYPE="text"
+export ARR_OPTIONS
 MODE="markdown"
 DISABLE_PREVIEW="false"
 PROTECT="false"
@@ -44,10 +48,44 @@ LINE_BREAK=$'\n'
 FILE_CONF="/etc/telegram-notify.conf"
 
 # -------------------------------------------------------
+#   Output and global functions
+# -------------------------------------------------------
+
+print_multiline() {
+  local _line
+  local _target=$1; shift
+  local _level=$1; shift
+
+  [ "$_target" -gt 0 ] && [ "$_target" -lt 3 ] || _target=2
+  printf "%s %s\n" "$_level" "$1" 1>&"$_target"; shift
+  for _line in "${@:1}"; do
+    printf "%s +               %s\n" "$_level" "$_line" 1>&"$_target";
+  done
+}
+
+verbose() { [ "${VERBOSE}" = "true"  ] && print_multiline 2 "[Verbose]" "$@"; }
+debug()   { [ "${DEBUG}"   = "true"  ] && print_multiline 2 "[Debug]  " "$@"; }
+info()    { [ "${QUIET}"   = "false" ] && print_multiline 1 "[Info]   " "$@"; }
+warning() { [ "${QUIET}"   = "false" ] && print_multiline 2 "[Warning]" "$@"; }
+error()   { [ "${QUIET}"   = "false" ] && print_multiline 2 "[Error]  " "$@"; }
+alert()   {                               print_multiline 2 "[Alert]  " "$@"; } # never suppress alerts
+
+trim() {
+  # remove leading whitespace characters
+  local _result=$1
+  _result="${_result#"${_result%%[![:space:]]*}"}"
+  # remove trailing whitespace characters
+  _result="${_result%"${_result##*[![:space:]]}"}"
+  printf "%s" "$_result"
+  return 0
+}
+
+
+# -------------------------------------------------------
 #   Check tools availability
 # -------------------------------------------------------
 
-command -v curl >/dev/null 2>&1 || { echo "[Error] Please install curl"; exit 1; }
+command -v curl >/dev/null 2>&1 || { alert "Please install 'curl'"; exit 1; }
 
 # -------------------------------------------------------
 #   Unicode icons
@@ -55,7 +93,7 @@ command -v curl >/dev/null 2>&1 || { echo "[Error] Please install curl"; exit 1;
 
 get_utf_locale() {
     # and use first one having UTF-8, or current one as fallback
-    command -v locale >/dev/null 2>&1 || { [ "${QUIET}" = "false" ] && echo "[Error] Please install locale"; return 1; }
+    command -v locale >/dev/null 2>&1 || { error "Please install 'locale'"; return 1; }
 
     locale -a | while read -er line; do
         local _lang=${line,,}
@@ -87,18 +125,6 @@ get_unicode_string() {
 #   Load config
 # -------------------------------------------------------
 
-debug() { printf "[Debug] %s\n" "$@" 1>&2; }
-
-trim() {
-  # remove leading whitespace characters
-  local _result=$1
-  _result="${_result#"${_result%%[![:space:]]*}"}"
-  # remove trailing whitespace characters
-  _result="${_result%"${_result##*[![:space:]]}"}"
-  printf "%s" "$_result"
-  return 0
-}
-
 read_config() {
   # read config file removing comments
   [ -f "${FILE_CONF}" ] || return 1
@@ -117,15 +143,15 @@ read_config() {
       _key=${_key^^} # upper case
 
       if [ "$_key" = "$1" ]; then
-        if [ "${DEBUG}" = "ok" ]; then
+        if [ "${DEBUG}" = "true" ]; then
           if [ "$_key" = "API_KEY" ]; then # hide API key in debug output
-            [ "$_value" = "" ] && debug "Config : Key='${_key}'; Value=###missing###"
+            [ "$_value" = "" ] && debug "Config        : Key='${_key}'; Value=###missing###"
             if [ ! "$_value" = "" ]; then
-              [ "$DEBUG_KEY" != "ok" ] && debug "Config : Key='${_key}'; Value=***** (show with --debug_key)"
-              [ "$DEBUG_KEY" =  "ok" ] && debug "Config : Key='${_key}'; Value='${_value}'"
+              [ "$DEBUG_KEY" != "true" ] && debug "Config        : Key='${_key}'; Value=***** (show with --debug_key)"
+              [ "$DEBUG_KEY" =  "true" ] && debug "Config        : Key='${_key}'; Value='${_value}'"
             fi
           else
-            debug "Config : Key='${_key}'; Value='${_value}'"
+            debug "Config        : Key='${_key}'; Value='${_value}'"
           fi
         fi
 
@@ -137,6 +163,77 @@ read_config() {
   done
   [ "$?" = 9 ] && return 0
   return 1
+}
+
+# -------------------------------------------------------
+#   Checking result of Telegram API call
+# -------------------------------------------------------
+
+read_from_json() {
+    # jq fallback: quick'n'dirty and not so save
+    verbose "Get value for : $2"
+    verbose "JSON          : $1"
+
+    echo "$1" | while IFS=',' read -ra _LINE; do # split by ','
+      verbose "Lines         : " "${_LINE[@]}"
+
+      for _segment in "${_LINE[@]}"; do
+        verbose "Segment       : ${_segment}"
+
+        echo "$_segment" | while IFS=':' read -ra _KEY_VALUE; do # split by ':'
+          verbose "Key/Value     : " "${_KEY_VALUE[@]}"
+
+          local _key="${_KEY_VALUE[0]}"
+          local _value
+          # remove quotes from key
+          _key=${_key//\"/}
+          if [ "${#_KEY_VALUE[@]}" -gt 2 ]; then
+            _value="${_KEY_VALUE[1]}:${_KEY_VALUE[*]:2}" # all values if value contains ':'; No loop rejoin only first
+          else
+            _value="${_KEY_VALUE[1]}"
+          fi
+
+          [ "$_key" = "$2" ] && printf "%s" "$_value" && exit 9
+        done
+        [ "$?" = 9 ] && exit 9
+      done
+      [ "$?" = 9 ] && exit 9
+    done
+    [ "$?" = 9 ] && return 0
+    return 1
+}
+
+check_telegram_response() {
+    local _jq_mode=0
+    command -v jq_ >/dev/null 2>&1 && _jq_mode=1
+    if [ $_jq_mode = 1 ]; then # use jq if available
+      debug "Parsing JSON using 'jq'..."
+      if [ "$(echo "$1" | jq '.ok')" = 'false' ]; then
+        printf "%s (code: %s)" "$(echo "$1" | jq '.description')" "$(echo "$1" | jq '.error_code')"  && return 1
+      fi
+      debug "Telegram API call with status 'ok'"
+      return 0
+    else
+      warning "Using insecure JSON parser, please install 'jq'"
+      local _json=$1
+      # remove json wrapper
+      _json=${_json//\{/}
+      _json=${_json//\}/}
+
+      local _rc=""
+      _rc=$(read_from_json "$_json" "ok")
+
+      if [ "$_rc" = 'false' ]; then
+        # get error message and code for error message
+        local _code=""
+        local _msg=""
+        _code=$(read_from_json "$_json" "error_code")
+        _msg=$(read_from_json "$_json" "description")
+
+        printf "%s (code: %s)" "$_msg" "$_code" && return 0
+      fi
+    fi
+    return 1
 }
 
 # -------------------------------------------------------
@@ -170,10 +267,14 @@ then
   echo "  --warning           Add a warning icon"
   echo "  --error             Add an error icon"
   echo "  --question          Add a question mark icon"
+  echo "  --exclamation       Add a red exclamation mark icon"
+  echo "  --bug               Add a bug icon"
+  echo "  --beetle            Add a beetle icon"
   echo "  --icon <code>       Add an icon by UTF code (ex 1F355)"
   echo "Other options are :"
   echo "  --debug             Display config file and JSON answer for debug"
   echo "  --debug_key         Display config file data with API key for debug"
+  echo "  --verbose           Display more details than --debug"
   echo "Here is an example of piped text :"
   echo "  echo 'text to be displayed' | telegram-notify --success --text -"
   exit
@@ -202,12 +303,17 @@ do
     "--warning") ICON=$(get_unicode_string "\U26A0"); shift; ;;
     "--error") ICON=$(get_unicode_string "\U1F6A8"); shift; ;;
     "--question") ICON=$(get_unicode_string "\U2753"); shift; ;;
+    "--exclamation") ICON=$(get_unicode_string "\U2757"); shift; ;;
+    "--bug") ICON=$(get_unicode_string "\U1F41B"); shift; ;;
+    "--beetle") ICON=$(get_unicode_string "\U1F41E"); shift; ;;
     "--icon") shift; ICON=$(get_unicode_string "\U$1"); shift; ;;
-    "--debug") DEBUG="ok"; shift; ;;
-    "--debug_key") DEBUG="ok"; DEBUG_KEY="ok"; shift; ;;
+    "--debug") DEBUG="true"; shift; ;;
+    "--debug_key") DEBUG="true"; DEBUG_KEY="true"; shift; ;;
+    "--verbose") DEBUG="true"; VERBOSE="true"; shift; ;;
     *) shift; ;;
   esac
 done
+[ "$VERBOSE" = "true" ] && QUIET="false"
 
 # -------------------------------------------------------
 #   Read configuration
@@ -216,16 +322,15 @@ done
 # if configuration file is present
 if [ -f "${FILE_CONF}" ]
 then
-	# display used config file unless --quiet parameter is used
-	[ "${QUIET}" = "false" ] && echo "[Info] Using configuration file ${FILE_CONF}"
+	# display used config file
+	info "Using configuration file ${FILE_CONF}"
 
   # use defaults from config
   API_KEY=$(read_config "API_KEY")
   USER_ID=$(read_config "USER_ID")
   SOCKS_PROXY=$(read_config "SOCKS_PROXY")
 else
-	# display warning unless --quiet parameter is used
-	[ "${QUIET}" = "false" ] && echo "[Warning] Configuration file missing ${FILE_CONF}"
+	warning "Configuration file missing ${FILE_CONF}"
 fi
 
 # overwrite defaults from config file with more specific command line arguments if provided
@@ -233,11 +338,11 @@ fi
 [ "${ARG_API_KEY}" != "" ] && API_KEY=${ARG_API_KEY}
 
 # check API key and User ID
-[ "${API_KEY}" = "" ] && { echo "[Error] Please provide API key or set it in ${FILE_CONF}"; exit 1; }
-[ "${USER_ID}" = "" ] && { echo "[Error] Please provide User ID or set it in ${FILE_CONF}"; exit 1; }
+[ "${API_KEY}" = "" ] && { alert "Please provide API key or set it in ${FILE_CONF}"; exit 1; }
+[ "${USER_ID}" = "" ] && { alert "Please provide User ID or set it in ${FILE_CONF}"; exit 1; }
 
 # Check for file existence
-[ "${FILE}" != "" ] && [ ! -f "${FILE}" ] && { echo "[Error] File ${FILE} doesn't exist"; exit 1; }
+[ "${FILE}" != "" ] && [ ! -f "${FILE}" ] && { error "File ${FILE} doesn't exist"; exit 1; }
 
 # generate temporary directory
 TMP_DIR=$(mktemp -t -d "telegram-XXXXXXXX")
@@ -309,7 +414,7 @@ case "${TYPE}" in
 
   # position
   "pos") 
-    # extract coordonates
+    # extract coordinates
     LATITUDE=$(echo "${POSITION}" | cut -d',' -f1)
     LONGITUDE=$(echo "${POSITION}" | cut -d',' -f2)
 
@@ -323,10 +428,10 @@ case "${TYPE}" in
   "audio") 
     # if needed, convert audio file
     IS_OPUS=$(file "${FILE}" | grep "Opus audio")
-    command -v ffmpeg >/dev/null 2>&1 && IS_FFMPEG="ok"
+    command -v ffmpeg >/dev/null 2>&1 && IS_FFMPEG="true"
 
     [ "${IS_OPUS}" != "" ] && TMP_AUDIO="${FILE}"
-    [ "${IS_OPUS}" = "" ] && [ "${IS_FFMPEG}" = "ok" ] && ffmpeg -i "${FILE}" -loglevel quiet -c libopus -ab 64k "${TMP_AUDIO}"
+    [ "${IS_OPUS}" = "" ] && [ "${IS_FFMPEG}" = "true" ] && ffmpeg -i "${FILE}" -loglevel quiet -c libopus -ab 64k "${TMP_AUDIO}"
 
     # if proper audio file
     if [ -f "${TMP_AUDIO}" ]
@@ -336,7 +441,7 @@ case "${TYPE}" in
       ARR_OPTIONS=( "${ARR_OPTIONS[@]}" "https://api.telegram.org/bot${API_KEY}/sendVoice" )
     else
       ARR_OPTIONS=( )
-      [ "${QUIET}" = "false" ] && echo "[Error] FFmpeg absent, Opus conversion impossible"
+      error "FFmpeg absent, Opus conversion impossible install 'ffmpeg'"
     fi
     ;;
 
@@ -352,19 +457,23 @@ then
   RESULT=$(curl "${ARR_OPTIONS[@]}")
 
   # if debug mode, display bot answer
-  if [ "${DEBUG}" = "ok" ]
-  then
-    echo "option : " "${ARR_OPTIONS[@]}"
-    echo "answer : " "${RESULT}"
-  fi
+  debug "Options       : ${ARR_OPTIONS[*]}"
+  debug "TG-API answer : ${RESULT}"
+
+  # checking answer
+  RESULT_CHECK=$(check_telegram_response "${RESULT}")
+  RC=$?
+  [ "$RESULT_CHECK" != "" ] && alert "$(printf "Telegram API failed with: %s\n" "$RESULT_CHECK")"
 
 #  else, nothing, error
 else
-  # display error message unless --quiet parameter is used
-  [ "${QUIET}" = "false" ] && echo "[Error] Nothing to notify"
+  RC=2
+  error "Nothing to notify (return code: ${RC})"
   
 fi
 
 # remove temporary directory
 rm -r "${TMP_DIR}"
 
+debug "Return code: ${RC}"
+exit $RC

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -205,7 +205,7 @@ read_from_json() {
 
 check_telegram_response() {
     local _jq_mode=0
-    command -v jq_ >/dev/null 2>&1 && _jq_mode=1
+    command -v jq >/dev/null 2>&1 && _jq_mode=1
     if [ $_jq_mode = 1 ]; then # use jq if available
       debug "Parsing JSON using 'jq'..."
       if [ "$(echo "$1" | jq '.ok')" = 'false' ]; then

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -172,7 +172,7 @@ fi
 [ "${USER_ID}" = "" ] && { echo "[Error] Please provide User ID or set it in ${FILE_CONF}"; exit 1; }
 
 # Check for file existence
-[ "${FILE}" != "" -a ! -f "${FILE}" ] && { echo "[error] File ${FILE} doesn't exist"; exit 1; }
+[ "${FILE}" != "" ] && [ ! -f "${FILE}" ] && { echo "[error] File ${FILE} doesn't exist"; exit 1; }
 
 # generate temporary directory
 TMP_DIR=$(mktemp -t -d "telegram-XXXXXXXX")
@@ -183,10 +183,10 @@ TMP_AUDIO="${TMP_DIR}/audio.ogg"
 # -------------------------------------------------------
 
 # if text is a file, get its content
-[ "${TYPE}" = "text" -a "${FILE}" != "" ] && TEXT=$(cat "${FILE}")
+[ "${TYPE}" = "text" ] && [ "${FILE}" != "" ] && TEXT=$(cat "${FILE}")
 
 # if text is to be read from pipe, get it
-[ ! -t 0 -a "${TEXT}" = "-" ] && TEXT=$(cat)
+[ ! -t 0 ] && [ "${TEXT}" = "-" ] && TEXT=$(cat)
 
 # convert \n to LF
 TEXT="${TEXT//$"\n"/${LINE_BREAK}}"
@@ -196,8 +196,8 @@ TEXT="${TEXT#"${TEXT%%[![:space:]]*}"}"
 TEXT="${TEXT%"${TEXT##*[![:space:]]}"}"
 
 # if title defined, add it with line break
-[ "${TITLE}" != "" -a "${MODE}" = "html" ] && TEXT="<b>${TITLE}</b>${LINE_BREAK}${LINE_BREAK}${TEXT}"
-[ "${TITLE}" != "" -a "${MODE}" = "markdown" ] && TEXT="*${TITLE}*${LINE_BREAK}${LINE_BREAK}${TEXT}"
+[ "${TITLE}" != "" ] && [ "${MODE}" = "html" ] && TEXT="<b>${TITLE}</b>${LINE_BREAK}${LINE_BREAK}${TEXT}"
+[ "${TITLE}" != "" ] && [ "${MODE}" = "markdown" ] && TEXT="*${TITLE}*${LINE_BREAK}${LINE_BREAK}${TEXT}"
 
 # if icon defined, include ahead of notification
 [ "${ICON}" != "" ] && TEXT="${ICON} ${TEXT}"
@@ -257,7 +257,7 @@ case "${TYPE}" in
     command -v ffmpeg >/dev/null 2>&1 && IS_FFMPEG="ok"
 
     [ "${IS_OPUS}" != "" ] && TMP_AUDIO="${FILE}"
-    [ "${IS_OPUS}" = "" -a "${IS_FFMPEG}" = "ok" ] && ffmpeg -i "${FILE}" -loglevel quiet -c libopus -ab 64k "${TMP_AUDIO}"
+    [ "${IS_OPUS}" = "" ] && [ "${IS_FFMPEG}" = "ok" ] && ffmpeg -i "${FILE}" -loglevel quiet -c libopus -ab 64k "${TMP_AUDIO}"
 
     # if proper audio file
     if [ -f "${TMP_AUDIO}" ]

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -281,8 +281,8 @@ then
   # if debug mode, display bot answer
   if [ "${DEBUG}" = "ok" ]
   then
-    echo "option : ${ARR_OPTIONS[@]}"
-    echo "answer : ${RESULT}" 
+    echo "option : " "${ARR_OPTIONS[@]}"
+    echo "answer : " "${RESULT}"
   fi
 
 #  else, nothing, error

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -25,6 +25,9 @@
 # ---------------------------------------------------
 
 # initialise variables
+API_KEY=""
+USER_ID=""
+SOCKS_PROXY=""
 DEBUG=""
 DEBUG_KEY=""
 TEXT=""
@@ -84,6 +87,8 @@ get_unicode_string() {
 #   Load config
 # -------------------------------------------------------
 
+debug() { printf "[Debug] %s\n" "$@" 1>&2; }
+
 trim() {
   # remove leading whitespace characters
   local _result=$1
@@ -97,35 +102,41 @@ trim() {
 read_config() {
   # read config file removing comments
   [ -f "${FILE_CONF}" ] || return 1
-  local _config=$(grep -oE "^[^#]*" "${FILE_CONF}") # read up to first '#' in line
+  local _config
+  _config=$(grep -oE "^[^#]*" "${FILE_CONF}") # read up to first '#' in line
 
   echo "${_config}" | while read -er _line; do # split on new line
-    echo "$_line" | while IFS='=' read -a _KEY_VALUE; do # split on "="
-      local _key=$(trim "${_KEY_VALUE[0]}")
-      local _value=$(trim "${_KEY_VALUE[1]}")
+    echo "$_line" | while IFS='=' read -ra _KEY_VALUE; do # split on "="
+      local _key
+      local _value
+      _key=$(trim "${_KEY_VALUE[0]}")
+      _value=$(trim "${_KEY_VALUE[1]}")
 
       # normalize key
       _key=${_key//-/_}
       _key=${_key^^} # upper case
 
-      [ "$_key" = "API_KEY" ]     && API_KEY=$_value
-      [ "$_key" = "USER_ID" ]     && USER_ID=$_value
-      [ "$_key" = "SOCKS_PROXY" ] && SOCKS_PROXY=$_value
-
-      if [ "${DEBUG}" = "ok" ]; then
-        if [ "$_key" = "API_KEY" ]; then # hide API key in debug output
-          [ "$_value" = "" ] && echo "[Warning] Config file: Key='${_key}'; Value=###missing###"
-          if [ ! "$_value" = "" ]; then
-            [ "$DEBUG_KEY" != "ok" ] && echo "[Info]    Config file: Key='${_key}'; Value=***** (show with --debug_key)"
-            [ "$DEBUG_KEY" =  "ok" ] && echo "[Info]    Config file: Key='${_key}'; Value='${_value}'"
+      if [ "$_key" = "$1" ]; then
+        if [ "${DEBUG}" = "ok" ]; then
+          if [ "$_key" = "API_KEY" ]; then # hide API key in debug output
+            [ "$_value" = "" ] && debug "Config : Key='${_key}'; Value=###missing###"
+            if [ ! "$_value" = "" ]; then
+              [ "$DEBUG_KEY" != "ok" ] && debug "Config : Key='${_key}'; Value=***** (show with --debug_key)"
+              [ "$DEBUG_KEY" =  "ok" ] && debug "Config : Key='${_key}'; Value='${_value}'"
+            fi
+          else
+            debug "Config : Key='${_key}'; Value='${_value}'"
           fi
-        else
-          echo "[Info]    Config file: Key='${_key}'; Value='${_value}'"
         fi
+
+        printf "%s" "$_value"
+        exit 9
       fi
     done
+    [ "$?" = 9 ] && exit 9
   done
-  return 0
+  [ "$?" = 9 ] && return 0
+  return 1
 }
 
 # -------------------------------------------------------
@@ -208,7 +219,10 @@ then
 	# display used config file unless --quiet parameter is used
 	[ "${QUIET}" = "false" ] && echo "[Info] Using configuration file ${FILE_CONF}"
 
-  read_config # use defaults from config
+  # use defaults from config
+  API_KEY=$(read_config "API_KEY")
+  USER_ID=$(read_config "USER_ID")
+  SOCKS_PROXY=$(read_config "SOCKS_PROXY")
 else
 	# display warning unless --quiet parameter is used
 	[ "${QUIET}" = "false" ] && echo "[Warning] Configuration file missing ${FILE_CONF}"
@@ -241,10 +255,8 @@ TMP_AUDIO="${TMP_DIR}/audio.ogg"
 
 # convert \n to LF
 TEXT="${TEXT//$"\n"/${LINE_BREAK}}"
-# remove leading whitespace characters
-TEXT="${TEXT#"${TEXT%%[![:space:]]*}"}"
-# remove trailing whitespace characters
-TEXT="${TEXT%"${TEXT##*[![:space:]]}"}"
+# remove leading and whitespace characters
+TEXT=$(trim "$TEXT")
 
 # if title defined, add it with line break
 [ "${TITLE}" != "" ] && [ "${MODE}" = "html" ] && TEXT="<b>${TITLE}</b>${LINE_BREAK}${LINE_BREAK}${TEXT}"

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -230,8 +230,9 @@ check_telegram_response() {
         _code=$(read_from_json "$_json" "error_code")
         _msg=$(read_from_json "$_json" "description")
 
-        printf "%s (code: %s)" "$_msg" "$_code" && return 0
+        printf "%s (code: %s)" "$_msg" "$_code" && return 1
       fi
+      return 0
     fi
     return 1
 }

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -93,7 +93,7 @@ command -v curl >/dev/null 2>&1 || { alert "Please install 'curl'"; exit 1; }
 
 get_utf_locale() {
     # and use first one having UTF-8, or current one as fallback
-    command -v locale >/dev/null 2>&1 || { error "Please install 'locale'"; return 1; }
+    command -v locale >/dev/null 2>&1 || { error "Please install 'locales'"; return 1; }
 
     locale -a | while read -er line; do
         local _lang=${line,,}

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -45,6 +45,40 @@ FILE_CONF="/etc/telegram-notify.conf"
 command -v curl >/dev/null 2>&1 || { echo "[Error] Please install curl"; exit 1; }
 
 # -------------------------------------------------------
+#   Unicode icons
+# -------------------------------------------------------
+
+get_utf_locale() {
+    # and use first one having UTF-8, or current one as fallback
+    command -v locale >/dev/null 2>&1 || { [ "${QUIET}" = "false" ] && echo "[Error] Please install locale"; return 1; }
+
+    locale -a | while read -er line; do
+        local _lang=${line,,}
+        local _lc_lang=${_lang,,}
+        if [ "${_lc_lang}" != "${_lc_lang/utf/}" ]; then
+          printf "%s" "$_lang"
+          exit 9
+        fi
+    done
+    [ "$?" -eq 9 ] && exit 0
+    printf "%s" "$LANG"
+    return 1
+}
+
+get_unicode_string() {
+    # support unicode input even if current locale has no UTF-8
+    local _lang=$LANG;
+    local _lc_lang=${LANG,,}
+    if [ "${_lc_lang}" == "${_lc_lang/utf/}" ]; then # checking for lower case utf
+      # currently no UTF-8 support, checking available locales for UTF-8 support
+      _lang=$(get_utf_locale)
+    fi
+    command -v printf >/dev/null 2>&1 && LANG=$_lang printf "%b\n" "$1" && return 1;
+    LANG=$_lang echo -e "$1" && return 0
+    return 1
+}
+
+# -------------------------------------------------------
 #   Loop to load arguments
 # -------------------------------------------------------
 
@@ -102,11 +136,11 @@ do
     "--config") shift; FILE_CONF="$1"; shift; ;;
     "--user") shift; USER_ID="$1"; shift; ;;
     "--key") shift; API_KEY="$1"; shift; ;;
-    "--success") ICON=$(echo -e "\U2705"); shift; ;;
-    "--warning") ICON=$(echo -e "\U26A0"); shift; ;;
-    "--error") ICON=$(echo -e "\U1F6A8"); shift; ;;
-    "--question") ICON=$(echo -e "\U2753"); shift; ;;
-    "--icon") shift; ICON=$(echo -e "\U$1"); shift; ;;
+    "--success") ICON=$(get_unicode_string "\U2705"); shift; ;;
+    "--warning") ICON=$(get_unicode_string "\U26A0"); shift; ;;
+    "--error") ICON=$(get_unicode_string "\U1F6A8"); shift; ;;
+    "--question") ICON=$(get_unicode_string "\U2753"); shift; ;;
+    "--icon") shift; ICON=$(get_unicode_string "\U$1"); shift; ;;
     "--debug") DEBUG="ok"; shift; ;;
     *) shift; ;;
   esac

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -157,11 +157,11 @@ then
 	[ "${QUIET}" = "false" ] && echo "[Info] Using configuration file ${FILE_CONF}"
 
 	# if needed, load from configuration file
-	[ "${API_KEY}" = "" ] && API_KEY=$(cat "${FILE_CONF}" | grep "api-key=" | cut -d'=' -f2)
-	[ "${USER_ID}" = "" ] && USER_ID=$(cat "${FILE_CONF}" | grep "user-id=" | cut -d'=' -f2)
+	[ "${API_KEY}" = "" ] && API_KEY=$(grep "api-key=" "${FILE_CONF}" | cut -d'=' -f2)
+	[ "${USER_ID}" = "" ] && USER_ID=$(grep "user-id=" "${FILE_CONF}" | cut -d'=' -f2)
 
 	# load socks proxy from configuration file
-	SOCKS_PROXY=$(cat "${FILE_CONF}" | grep "socks-proxy=" | cut -d'=' -f2)
+	SOCKS_PROXY=$(grep "socks-proxy=" "${FILE_CONF}" | cut -d'=' -f2)
 else
 	# display warning unless --quiet parameter is used
 	[ "${QUIET}" = "false" ] && echo "[Warning] Configuration file missing ${FILE_CONF}"

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -25,6 +25,8 @@
 # ---------------------------------------------------
 
 # initialise variables
+DEBUG=""
+DEBUG_KEY=""
 TEXT=""
 ICON=""
 TYPE="text"
@@ -69,13 +71,61 @@ get_unicode_string() {
     # support unicode input even if current locale has no UTF-8
     local _lang=$LANG;
     local _lc_lang=${LANG,,}
-    if [ "${_lc_lang}" == "${_lc_lang/utf/}" ]; then # checking for lower case utf
+    if [ "${_lc_lang}" = "${_lc_lang/utf/}" ]; then # checking for lower case utf
       # currently no UTF-8 support, checking available locales for UTF-8 support
       _lang=$(get_utf_locale)
     fi
     command -v printf >/dev/null 2>&1 && LANG=$_lang printf "%b\n" "$1" && return 1;
     LANG=$_lang echo -e "$1" && return 0
     return 1
+}
+
+# -------------------------------------------------------
+#   Load config
+# -------------------------------------------------------
+
+trim() {
+  # remove leading whitespace characters
+  local _result=$1
+  _result="${_result#"${_result%%[![:space:]]*}"}"
+  # remove trailing whitespace characters
+  _result="${_result%"${_result##*[![:space:]]}"}"
+  printf "%s" "$_result"
+  return 0
+}
+
+read_config() {
+  # read config file removing comments
+  [ -f "${FILE_CONF}" ] || return 1
+  local _config=$(grep -oE "^[^#]*" "${FILE_CONF}") # read up to first '#' in line
+
+  echo "${_config}" | while read -er _line; do # split on new line
+    echo "$_line" | while IFS='=' read -a _KEY_VALUE; do # split on "="
+      local _key=$(trim "${_KEY_VALUE[0]}")
+      local _value=$(trim "${_KEY_VALUE[1]}")
+
+      # normalize key
+      _key=${_key//-/_}
+      _key=${_key^^} # upper case
+
+      [ "$_key" = "API_KEY" ]     && API_KEY=$_value
+      [ "$_key" = "USER_ID" ]     && USER_ID=$_value
+      [ "$_key" = "SOCKS_PROXY" ] && SOCKS_PROXY=$_value
+
+      if [ "${DEBUG}" = "ok" ]; then
+        if [ "$_key" = "API_KEY" ]; then # hide API key in debug output
+          [ "$_value" = "" ] && echo "[Warning] Config file: Key='${_key}'; Value=###missing###"
+          if [ ! "$_value" = "" ]; then
+            [ "$DEBUG_KEY" != "ok" ] && echo "[Info]    Config file: Key='${_key}'; Value=***** (show with --debug_key)"
+            [ "$DEBUG_KEY" =  "ok" ] && echo "[Info]    Config file: Key='${_key}'; Value='${_value}'"
+          fi
+        else
+          echo "[Info]    Config file: Key='${_key}'; Value='${_value}'"
+        fi
+      fi
+    done
+  done
+  return 0
 }
 
 # -------------------------------------------------------
@@ -111,7 +161,8 @@ then
   echo "  --question          Add a question mark icon"
   echo "  --icon <code>       Add an icon by UTF code (ex 1F355)"
   echo "Other options are :"
-  echo "  --debug             Display JSON answer for debug"
+  echo "  --debug             Display config file and JSON answer for debug"
+  echo "  --debug_key         Display config file data with API key for debug"
   echo "Here is an example of piped text :"
   echo "  echo 'text to be displayed' | telegram-notify --success --text -"
   exit
@@ -134,14 +185,15 @@ do
     "--silent") SILENT="true"; shift; ;;
     "--quiet") QUIET="true"; shift; ;;
     "--config") shift; FILE_CONF="$1"; shift; ;;
-    "--user") shift; USER_ID="$1"; shift; ;;
-    "--key") shift; API_KEY="$1"; shift; ;;
+    "--user") shift; ARG_USER_ID="$1"; shift; ;;
+    "--key") shift; ARG_API_KEY="$1"; shift; ;;
     "--success") ICON=$(get_unicode_string "\U2705"); shift; ;;
     "--warning") ICON=$(get_unicode_string "\U26A0"); shift; ;;
     "--error") ICON=$(get_unicode_string "\U1F6A8"); shift; ;;
     "--question") ICON=$(get_unicode_string "\U2753"); shift; ;;
     "--icon") shift; ICON=$(get_unicode_string "\U$1"); shift; ;;
     "--debug") DEBUG="ok"; shift; ;;
+    "--debug_key") DEBUG="ok"; DEBUG_KEY="ok"; shift; ;;
     *) shift; ;;
   esac
 done
@@ -156,23 +208,22 @@ then
 	# display used config file unless --quiet parameter is used
 	[ "${QUIET}" = "false" ] && echo "[Info] Using configuration file ${FILE_CONF}"
 
-	# if needed, load from configuration file
-	[ "${API_KEY}" = "" ] && API_KEY=$(grep "api-key=" "${FILE_CONF}" | cut -d'=' -f2)
-	[ "${USER_ID}" = "" ] && USER_ID=$(grep "user-id=" "${FILE_CONF}" | cut -d'=' -f2)
-
-	# load socks proxy from configuration file
-	SOCKS_PROXY=$(grep "socks-proxy=" "${FILE_CONF}" | cut -d'=' -f2)
+  read_config # use defaults from config
 else
 	# display warning unless --quiet parameter is used
 	[ "${QUIET}" = "false" ] && echo "[Warning] Configuration file missing ${FILE_CONF}"
 fi
+
+# overwrite defaults from config file with more specific command line arguments if provided
+[ "${ARG_USER_ID}" != "" ] && USER_ID=${ARG_USER_ID}
+[ "${ARG_API_KEY}" != "" ] && API_KEY=${ARG_API_KEY}
 
 # check API key and User ID
 [ "${API_KEY}" = "" ] && { echo "[Error] Please provide API key or set it in ${FILE_CONF}"; exit 1; }
 [ "${USER_ID}" = "" ] && { echo "[Error] Please provide User ID or set it in ${FILE_CONF}"; exit 1; }
 
 # Check for file existence
-[ "${FILE}" != "" ] && [ ! -f "${FILE}" ] && { echo "[error] File ${FILE} doesn't exist"; exit 1; }
+[ "${FILE}" != "" ] && [ ! -f "${FILE}" ] && { echo "[Error] File ${FILE} doesn't exist"; exit 1; }
 
 # generate temporary directory
 TMP_DIR=$(mktemp -t -d "telegram-XXXXXXXX")

--- a/telegram/telegram-notify
+++ b/telegram/telegram-notify
@@ -189,7 +189,11 @@ TMP_AUDIO="${TMP_DIR}/audio.ogg"
 [ ! -t 0 -a "${TEXT}" = "-" ] && TEXT=$(cat)
 
 # convert \n to LF
-TEXT=$(echo "${TEXT}" | sed 's:\\n:\n:g')
+TEXT="${TEXT//$"\n"/${LINE_BREAK}}"
+# remove leading whitespace characters
+TEXT="${TEXT#"${TEXT%%[![:space:]]*}"}"
+# remove trailing whitespace characters
+TEXT="${TEXT%"${TEXT##*[![:space:]]}"}"
 
 # if title defined, add it with line break
 [ "${TITLE}" != "" -a "${MODE}" = "html" ] && TEXT="<b>${TITLE}</b>${LINE_BREAK}${LINE_BREAK}${TEXT}"

--- a/telegram/telegram-notify.conf
+++ b/telegram/telegram-notify.conf
@@ -2,6 +2,9 @@
 #   /etc/telegram-notify.conf    #
 # -------------------------------#
 
+# Note: Please get in contact, if any value contains a '#'
+#       Everything after '#' will be ignored at the moment
+
 [general]
 api-key=YourAPIKey
 user-id=YourUserOrChannelID


### PR DESCRIPTION
Hello @NicolasBernaerts,

made some changes as recommended by ShellCheck and added:
1) Trim whitespace from TEXT
2) '\n' support and trim for TITLE
3) Support for comments in config file
4) UTF-8 output if current LANG wasn't set to to an UTF-8 locale (ex. if called within reduced or background environment of another process)

Test UTF-8 case with, works now if there is at least one installed locale (check with 'locale -a') having UTF-8:
LANG=C bash telegram-notify --text 'UTF-8 code instead of icon' --warning

One commit per change, so you can take over what you like.

Greets, Awalon